### PR TITLE
ci: exclude NVIDIA CUDA/kenlm/soxr from license gate

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -13,3 +13,10 @@ jobs:
       # kenlm 0.3.0 (only PyPI release) fails to compile on Python 3.13+
       # (uses private CPython C-API removed in 3.13); 3.12 builds the wheel fine.
       python_version: '3.12'
+      # torch pulls NVIDIA CUDA runtime wheels (proprietary-but-redistributable) and a
+      # couple of packages that ship no parseable license metadata. They are runtime
+      # backend deps, not part of this plugin's distributable surface; exclude them from
+      # the copyleft/Other/Error gate. kenlm reports no license metadata ("Error").
+      # soxr (LGPL, via librosa/openai-whisper) is an unmodified imported library.
+      exclude_packages: >-
+        (?i:^nvidia-.*([=<>!~ @;].*)?$)|(?i:^cuda-bindings([=<>!~ @;].*)?$)|(?i:^cuda-toolkit([=<>!~ @;].*)?$)|(?i:^kenlm([=<>!~ @;].*)?$)|(?i:^soxr([=<>!~ @;].*)?$)


### PR DESCRIPTION
License Check fails on dev because torch pulls proprietary NVIDIA CUDA runtime wheels, kenlm ships no license metadata, and soxr (LGPL, via librosa/openai-whisper) is flagged WeakCopyleft. None are direct deps of this Apache-2.0 plugin.

Adds an `exclude_packages` regex to the license-check caller so these backend-only deps don't trip the copyleft/Other/Error gate. Verified green via workflow_dispatch on the prior branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)